### PR TITLE
Add CSP to response headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: a1936164b458a807a69d9113fc28fa2d66566386
+  revision: 6094ff718f0480a36a57bd8ac4d7ef1258b62d77
   branch: develop
   specs:
     pafs_core (0.0.2)
@@ -65,13 +65,13 @@ GEM
       airbrake-ruby (~> 1.7)
     airbrake-ruby (1.7.1)
     arel (6.0.4)
-    aws-sdk (2.8.0)
-      aws-sdk-resources (= 2.8.0)
-    aws-sdk-core (2.8.0)
+    aws-sdk (2.8.5)
+      aws-sdk-resources (= 2.8.5)
+    aws-sdk-core (2.8.5)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.0)
-      aws-sdk-core (= 2.8.0)
+    aws-sdk-resources (2.8.5)
+      aws-sdk-core (= 2.8.5)
     aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     benchmark-ips (2.7.2)
@@ -414,4 +414,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.4
+   1.14.6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,24 @@
+# Play nice with Ruby 3 (and rubocop)
 # frozen_string_literal: true
+
 class ApplicationController < PafsCore::ApplicationController
+  include PafsCore::CustomHeaders
+
   helper PafsCore::Engine.helpers
+
    # This is a nested template that ultimately calls the gov uk template layout
   # This allows us to auto insert code into any of the hooks provided by the GDS layout.
   layout ->(_) { "pafs" }
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  before_action :custom_headers
+
+  private
+
+  def custom_headers
+    response_headers!(response)
+  end
+
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-286

Following a PEN test it was flagged that the service has not specified a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in the response headers sent back from the app to the clients browser.

For reference CSP

> [..] is an HTTP response header that restricts the browser to loading external assets such as scripts, styles or media from a wide variety of sources — as well as inline scripts. It is intended to prevent wide categories of attacks, such as cross-site scripting (XSS), click-jacking and other forms of code injection.
>
> *https://blog.sqreen.io/integrating-content-security-policy-into-your-rails-applications-4f883eed8f45/*

The actual code to customise the response headers is held in [pafs_core](https://github.com/DEFRA/pafs_core/pull/128) so this change updates the `ApplicationController` to pull the `PafsCore::CustomHeaders` module in and ensure all pages that originate from **pafs-admin** also apply the CSP.