### PR TITLE
Update to latest Content-Security-Policy impl.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: 6094ff718f0480a36a57bd8ac4d7ef1258b62d77
+  revision: adb884d660abe01fc226b53435f9a39e0d4c8e7e
   branch: develop
   specs:
     pafs_core (0.0.2)
@@ -20,6 +20,7 @@ GIT
       rails (~> 4.2.7.1)
       roo (~> 2.4.0)
       rubyXL
+      secure_headers (~> 3.6)
 
 GEM
   remote: https://rubygems.org/
@@ -65,13 +66,13 @@ GEM
       airbrake-ruby (~> 1.7)
     airbrake-ruby (1.7.1)
     arel (6.0.4)
-    aws-sdk (2.8.5)
-      aws-sdk-resources (= 2.8.5)
-    aws-sdk-core (2.8.5)
+    aws-sdk (2.8.7)
+      aws-sdk-resources (= 2.8.7)
+    aws-sdk-core (2.8.7)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.5)
-      aws-sdk-core (= 2.8.5)
+    aws-sdk-resources (2.8.7)
+      aws-sdk-core (= 2.8.7)
     aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     benchmark-ips (2.7.2)
@@ -315,6 +316,8 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    secure_headers (3.6.2)
+      useragent
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -350,6 +353,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
+    useragent (0.16.8)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (2.3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < PafsCore::ApplicationController
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :custom_headers
+  before_action :cache_busting
 
   private
 

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
+require "secure_headers"
+use SecureHeaders::Middleware
 
 require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-286

This is linked to an update to the Content Security Policy header, to cover content sourced from Google which are required for the analytics (see PR https://github.com/DEFRA/pafs_core/pull/131). That PR not only updates the CSP, but switches away from us setting the CSP to using the [Secure Headers](https://github.com/twitter/secureheaders) gem from **Twitter** to do it.

Going forward this will give us the ability to set other security related headers, plus it includes the ability to work with nonce values for inline scripts.

So the changes here are what are required to work with an updated **pafs_core**.