### PR TITLE
Fix Passenger spawn error caused by Secure Headers

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,8 +1,8 @@
+# Play nice with Ruby 3 (and rubocop)
 # frozen_string_literal: true
 
 # This file is used by Rack-based servers to start the application.
-require "secure_headers"
-use SecureHeaders::Middleware
-
 require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application
+
+use SecureHeaders::Middleware


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-286

In **pafs_core** commit 423d2e2 we not only amended the Content-Security-Policy itself to cater for the Google Analytics content we use, we also switched to using the [Secure Headers](https://github.com/twitter/secureheaders) gem to ensure this was added to all responses.

All tests passed and locally and in CI everything seemed fine, however when deployed it broke the app. Our investigation found that having added the gem, calling `require "secure_headers"` in the `config.ru` of either the front or back office apps threw an error when rails was being loaded.

Th difference was [Passenger](https://www.phusionpassenger.com/). It seems whilst that was fine when just using something like Webrick, when using **Passenger** we kept getting `no method errors`. Locally it would be

```bash
[ 2017-03-20 14:58:02.2697 51806/0x10acf6000 age/Cor/App/Implementation.cpp:304 ]: Could not spawn process for application /Users/acruikshanks/projects/ea/pafs-user: An error occurred while starting up the preloader.
  Error ID: 8e4c40f8
  Error details saved to: /var/folders/jr/dd8l7yk93rngqz11cq0kftd40000gn/T//passenger-error-NuSN3c.html
  Message from application: undefined method `all_helpers_from_path' for ActionController::Base:Class (NoMethodError)
```

On our app servers it was `protect_from_forgery()` that was not defined. Removing the require line from the config.ru resolves the issue and allows the **Passenger** process to spawn, whilst still ensuring the CSP comes through.