### PR TITLE
Run bundle update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ group :test do
   gem "capybara"
   gem "database_cleaner"
   gem "simplecov", require: false
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 0.6", require: false
 end
 
 group :production, :edge, :qa, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: adb884d660abe01fc226b53435f9a39e0d4c8e7e
+  revision: 8dfb2a5e5f2b2576b827c855c544b2192f4e048e
   branch: develop
   specs:
     pafs_core (0.0.2)
@@ -62,17 +62,17 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrake (5.7.1)
-      airbrake-ruby (~> 1.7)
-    airbrake-ruby (1.7.1)
+    airbrake (5.8.1)
+      airbrake-ruby (~> 1.8)
+    airbrake-ruby (1.8.0)
     arel (6.0.4)
-    aws-sdk (2.8.7)
-      aws-sdk-resources (= 2.8.7)
-    aws-sdk-core (2.8.7)
+    aws-sdk (2.8.10)
+      aws-sdk-resources (= 2.8.10)
+    aws-sdk-core (2.8.10)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.7)
-      aws-sdk-core (= 2.8.7)
+    aws-sdk-resources (2.8.10)
+      aws-sdk-core (= 2.8.10)
     aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     benchmark-ips (2.7.2)
@@ -81,7 +81,7 @@ GEM
     bstard (0.2.4)
     builder (3.2.3)
     byebug (9.0.6)
-    capybara (2.12.0)
+    capybara (2.13.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -92,8 +92,8 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     clamav-client (3.1.0)
-    codeclimate-test-reporter (1.0.5)
-      simplecov
+    codeclimate-test-reporter (0.6.0)
+      simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -132,7 +132,7 @@ GEM
       i18n (~> 0.5)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.17)
+    ffi (1.9.18)
     ffi-proj4 (0.2.0)
       ffi (>= 1.0.0)
     font-awesome-sass (4.5.0)
@@ -165,11 +165,11 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     i18n (0.8.1)
     iniparse (1.4.2)
-    jbuilder (2.6.1)
-      activesupport (>= 3.0.0, < 5.1)
+    jbuilder (2.6.3)
+      activesupport (>= 3.0.0, < 5.2)
       multi_json (~> 1.2)
     jmespath (1.3.1)
-    jquery-rails (4.2.2)
+    jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -193,7 +193,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.4.1)
       launchy (~> 2.2)
-    libv8 (3.16.14.17)
+    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -209,11 +209,11 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    msgpack (1.0.3)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -225,7 +225,7 @@ GEM
     passenger (5.0.30)
       rack
       rake (>= 0.8.1)
-    pg (0.19.0)
+    pg (0.20.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -321,7 +321,7 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simplecov (0.13.0)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -344,14 +344,14 @@ GEM
       ref
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.6)
+    tilt (2.0.7)
     trollop (2.1.2)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.4)
+    uglifier (3.1.9)
       execjs (>= 0.3.0, < 3)
     useragent (0.16.8)
     warden (1.2.7)
@@ -374,7 +374,7 @@ DEPENDENCIES
   benchmark-ips
   byebug
   capybara
-  codeclimate-test-reporter
+  codeclimate-test-reporter (~> 0.6)
   coffee-rails (~> 4.1.0)
   cumberland (~> 0.0.1)!
   database_cleaner


### PR DESCRIPTION
Simply running bundle update to ensure dependencies are at the latest versions, and then confirming there are no issues.

The only found was with `codeclimate-test-reporter`. Versions below 1.0 have been deprecated because they have changed the way test coverage is collected and reported.

The older versions still work, so we've decided due to time pressures rather than focus now on updating the project to work with version 1.0, we'll instead lock our version down to the latest 0.x release.