### PR TITLE
Fix missing translations for footer content

### DIFF
--- a/app/views/layouts/pafs.html.erb
+++ b/app/views/layouts/pafs.html.erb
@@ -43,7 +43,7 @@
 
 <% content_for :footer_top do %>
   <div class="ea-footer">
-    <p><%= t('global.footer_support_text') %> <%= link_to t("global.helpline_telephone_number"), "tel:#{t "global.helpline_telephone_number_uri" }" %></p>
+    <p><%= t('global.footer_support_text') %> <%= link_to t("global.helpline_telephone_number"), "tel:#{t("global.helpline_telephone_number").delete(" ") }" %></p>
     <div class="revision" aria-hidden="true">Build: <%= revision_hash %></div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  global:
+    footer_support_text: "Any issues call CIS service desk on 80 80 or if external "
+    helpline_telephone_number: "08708 508 082"
+    support_email: "pafs-support@environment-agency.gov.uk"
   date:
     formats:
       default: "%d/%m/%Y"


### PR DESCRIPTION
The admin layout borrows heavily from [pafs-user](https://github.com/DEFRA/pafs-user), but in doing so we never added all the translations needed to support it.

This change fixes that, by adding in the missing translations, specifically the support content and phone number.