### PR TITLE
Added reset consented flag to programme upload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/pafs_core
-  revision: 9f698304229a60cabfc69d533e6042cff26de0ed
+  revision: ced0c719415fb2c04918613340971c80991e7af8
   branch: develop
   specs:
     pafs_core (0.0.2)

--- a/app/controllers/admin/program_uploads_controller.rb
+++ b/app/controllers/admin/program_uploads_controller.rb
@@ -26,8 +26,7 @@ class Admin::ProgramUploadsController < ApplicationController
   end
 
   def create
-    @upload = program_uploader.upload(program_uploads_params.
-                                      fetch(:program_upload_file, nil))
+    @upload = program_uploader.upload(program_uploads_params)
 
     if @upload.valid? && @upload.save
       # start the background job
@@ -41,7 +40,7 @@ class Admin::ProgramUploadsController < ApplicationController
 
 private
   def program_uploads_params
-    params.require(:program_upload).permit(:program_upload_file)
+    params.require(:program_upload).permit(:program_upload_file, :reset_consented_flag)
   end
 
   def program_uploader

--- a/app/views/admin/program_uploads/new.html.erb
+++ b/app/views/admin/program_uploads/new.html.erb
@@ -8,12 +8,6 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <p><%= t(".description") %></p>
-      <div class="notice">
-        <i class="icon icon-important">
-          <span class="visuallyhidden">Warning</span>
-        </i>
-        <strong class="bold-small"><%= t(".notice") %></strong>
-      </div>
     </div>
   </div>
   <div class="form-group">
@@ -24,6 +18,31 @@
         aria: { labelledby: "file-upload" } %>
       <%= f.hidden_field :id %>
     <% end %>
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <div class="notice">
+          <i class="icon icon-important">
+            <span class="visuallyhidden">Important:</span>
+          </i>
+          <strong class="bold-small"><%= t(".notice") %></strong>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= f.check_box :reset_consented_flag, label: t(".reset_label") %>
+    </div>
     <%= f.submit t(".upload_and_process_label"), class: 'button' %>
+    <div class="grid-row headroom">
+      <div class="column-two-thirds">
+        <details role="group">
+          <summary role="button" aria-controls="import-help">
+            <span class="summary"><%= t(".import_help_title") %></span>
+          </summary>
+          <div class="panel panel-indent panel-border-narrow" id="import-help">
+            <%= t(".import_help_html") %>
+          </div>
+        </details>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,9 +50,20 @@ en:
     program_uploads:
       new:
         heading: "Import programme"
-        description: "Import the completed Flood and Coastal Erosion Risk Management programme for this year."
-        notice: "You must select the full FCERM program spreadsheet each time you import"
+        description: "Import the completed Flood and Coastal Erosion Risk Management programme."
+        notice: "Check the box below to reset the consented status for all projects in the service."
+        reset_label: "Reset consented status for all projects"
         upload_and_process_label: "Import"
+        import_help_title: "Do not want to import the full programme?"
+        import_help_html: >
+          <p>To import a partial programme or data fixes:
+          <ul class="list-bullet"><li>Select the file to upload</li>
+          <li><strong class="bold-small">DO NOT</strong> check the
+          'Reset consented status for all projects' box</li>
+          <li>Click the 'Import' button</li>
+          </ul>
+          </p>
+
       show:
         heading: "Import programme"
       status:


### PR DESCRIPTION
Enabled ability to choose whether a programme upload resets consented flag for all projects rather than forcing it to always happen. This enables us to upload data fixes or partial project data without affecting other projects.