### PR TITLE
[NO-JIRA] Re-Add demo page for outputting PAFS data for CAMC

### DIFF
--- a/app/controllers/admin/camc3_controller.rb
+++ b/app/controllers/admin/camc3_controller.rb
@@ -1,0 +1,18 @@
+class Admin::Camc3Controller < ApplicationController
+  before_action :authenticate_user!, :endpoint_enabled?
+  respond_to :json
+
+  def show
+    @project = PafsCore::Project.find_by_slug(params[:id])
+    @camc3 = PafsCore::Camc3Presenter.new(project: @project)
+
+    respond_with @camc3.attributes
+  end
+
+  protected
+
+  def endpoint_enabled?
+    return if ENV.fetch('ENABLE_ADMIN_JSON_PREVIEW', false)
+    head status: 404
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :program_uploads, except: [:edit, :update] do
       resources :program_upload_items, only: [:show]
     end
+    resources :camc3, only: [:show], controller: :camc3
   end
   devise_for :users, controllers: { passwords: "passwords" }
 


### PR DESCRIPTION
* Readds the json rendering page for projects to the admin
* Ensures the json is only rendered when the environment variable is set