### PR TITLE
[PM-563] Add devise email cc on invitation

### DIFF
--- a/app/mailers/account_request_mailer.rb
+++ b/app/mailers/account_request_mailer.rb
@@ -21,7 +21,7 @@ class AccountRequestMailer < ApplicationMailer
     )
     prevent_tracking
     mail(
-      bcc: ENV.fetch('DEVISE_INVITATION_BCC', nil),
+      cc: ENV.fetch('DEVISE_INVITATION_CC', nil),
       to: user.email, 
       subject: "Account created - FCERM project funding"
     )


### PR DESCRIPTION
* Allows the invitation email to be BCC'd to an email address when sent
* Used to allow an admin to resend the invite link in the event it is
caught by spam filters on the receiving end