### PR TITLE
Fix passenger critical severity security alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "govuk_publishing_components"
 gem "sucker_punch", "~> 2.0"
 
 # static pages
-gem "passenger", "~> 5.0.25", require: false
+gem "passenger", "~> 5.1.0", require: false
 gem "whenever", require: false
 
 # shared PAFS code

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
     overcommit (0.55.0)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
-    passenger (5.0.30)
+    passenger (5.1.12)
       rack
       rake (>= 0.8.1)
     pg (0.20.0)
@@ -535,7 +535,7 @@ DEPENDENCIES
   letter_opener
   overcommit
   pafs_core (~> 0.0)!
-  passenger (~> 5.0.25)
+  passenger (~> 5.1.0)
   pg (~> 0.20.0)
   poltergeist
   pry


### PR DESCRIPTION
This gem update to passenger fixes the issue with access to the system, a user could plant a symlink in /tmp that
resulted in a chosen-file overwrite attempt whenever passenger-install-nginx-module was run, using the access rights of the executing user, potentially even with chosen content.

[Link to original passenger commit change](https://github.com/phusion/passenger/commit/e5b4b0824d6b648525b4bf63d9fa37e5beeae441)
