### PR TITLE
[RUBY-3893] Update defra_ruby_template gem from 5.4.1 to 5.11.0 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       rubocop-factory_bot
       rubocop-rake
       rubocop-rspec
-    defra_ruby_template (5.4.1)
+    defra_ruby_template (5.11.0)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3893