### PR TITLE
Release v2.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Bump gem dependencies, including devise, devise\_invitable, faraday, jbuilder, net-imap, and nokogiri.
 
+**Fixed bugs:**
+
+- Pin cgi to the Ruby default gem version to avoid deploy-time activation conflicts.
+
 **Merged pull requests:**
 
 - Bump gem dependencies [\#929](https://github.com/DEFRA/pafs-admin/pull/929) ([brujeo](https://github.com/brujeo))

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "net-smtp"
 
 # Pin psych version to avoid GitHub CI failures on v5+: https://github.com/ruby/setup-ruby/issues/409
 gem "psych", "~> 4"
+# Pin cgi to the Ruby 3.2 default gem to avoid deploy-time activation conflicts.
+gem "cgi", "0.3.6"
 
 # Parsing PF Calculator
 gem "roo"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       rexml (>= 3.2)
       selenium-webdriver (>= 4.0)
       webrick (>= 1.7)
-    cgi (0.5.1)
+    cgi (0.3.6)
     childprocess (5.1.0)
       logger (~> 1.5)
     chronic (0.10.2)
@@ -570,6 +570,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-webmock
+  cgi (= 0.3.6)
   climate_control
   database_cleaner
   defra_ruby_style


### PR DESCRIPTION
## What changed

- Pins `cgi` to `0.3.6`, the Ruby 3.2 default gem version.
- Updates the changelog with the admin deploy hotfix.

## Why

The `v2.7.5` admin deploy failed with:

`Gem::LoadError: can't activate cgi-0.5.1, already activated cgi-0.3.6`

The deploy runtime had already activated Ruby's default `cgi` gem before Bundler activated the application bundle. Pinning the bundle to the same default version avoids the activation conflict.

## Validation

- `ruby -e 'gem "cgi", "0.3.6"; require "cgi"; puts Gem.loaded_specs["cgi"].version; load Gem.bin_path("bundler", "bundle")' exec ruby -e 'puts Gem.loaded_specs["cgi"].version; puts :ok'`
- `BUNDLE_USER_HOME=/private/tmp/pafs-admin-bundle-home bundle check`
- `RUBOCOP_CACHE_ROOT=/private/tmp/pafs-admin-rubocop-cache BUNDLE_USER_HOME=/private/tmp/pafs-admin-bundle-home bundle exec rubocop --format progress --no-parallel`
- `POL_FAILURE_NOTIFICATION_EMAIL=foo BUNDLE_USER_HOME=/private/tmp/pafs-admin-bundle-home bundle exec rspec`

RSpec result: 169 examples, 0 failures.
